### PR TITLE
Fix the data accuracy issue regarding EXP output

### DIFF
--- a/src/ObjectInfo.cpp
+++ b/src/ObjectInfo.cpp
@@ -1154,7 +1154,8 @@ DEFINE_HOOK(4F4583, GScreenClass_DrawOnTop_TheDarkSideOfTheMoon, 6)
 										sprintf(veterancy, "%s", "Elite");
 									else
 										sprintf(veterancy, "%s", "N/A");
-									append("Veterancy = %s (%.2f)", veterancy, pFoot->Veterancy.Veterancy);
+									double truncatedVet = floor(pFoot->Veterancy.Veterancy * 100) / 100.0;
+									append("Veterancy = %s (%.2f)", veterancy, truncatedVet);
 									display();
 								}
 							}


### PR DESCRIPTION
> [!Note]
> In Vanilla, the calculation method for experience points is `victimCost / ( ownerCost * [General] -> VeteranRatio )` , then *truncate* to 2 decimal places and store.

This leads to a unit with `[TechnoType] -> Cost=100`, after killing 3 units identical to itself, the experience should be `0.33 -> 0.66 -> 0.99`, so it does not level up.
But in ObjectInfo, this is not handled, this causes it to display as `0.33 -> 0.67 -> 1.0` in the same situation.

---
> [!Note]
> 在原版中经验值的计算方式是 `victimCost / ( ownerCost * [General] -> VeteranRatio )` 后 **截取** 2 位小数存入。

这就导致 `[TechnoType] -> Cost=100` 的单位在击杀 3 个与自己相同的单位后经验应当是 `0.33 -> 0.66 -> 0.99`，所以不会升到下一级。
但在 ObjectInfo中 并没有处理这点，这导致相同的情况下会显示为 `0.33 -> 0.67 -> 1.0`。